### PR TITLE
Allow non-OP players to use commands while restricting reset balance

### DIFF
--- a/src/main/java/com/baldeagle/country/CountryCommand.java
+++ b/src/main/java/com/baldeagle/country/CountryCommand.java
@@ -16,6 +16,11 @@ import net.minecraft.world.World;
 public class CountryCommand extends CommandBase {
 
     @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+    @Override
     public String getName() {
         return "country";
     }

--- a/src/main/java/com/baldeagle/economy/CommandEconomy.java
+++ b/src/main/java/com/baldeagle/economy/CommandEconomy.java
@@ -12,13 +12,18 @@ import net.minecraft.world.World;
 public class CommandEconomy extends CommandBase {
 
     @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+    @Override
     public String getName() {
         return "economy";
     }
 
     @Override
     public String getUsage(ICommandSender sender) {
-        return "/economy <player|country> <get|deposit|withdraw> <target> <amount>";
+        return "/economy <player|country> <get|deposit|withdraw|resetbalance> <target> [amount]";
     }
 
     @Override
@@ -43,6 +48,13 @@ public class CommandEconomy extends CommandBase {
                 if (action.equalsIgnoreCase("get")) {
                     long balance = EconomyManager.getPlayerBalance(world, uuid);
                     sender.sendMessage(new TextComponentString(targetPlayer.getName() + " balance: " + MoneyFormatUtil.format(balance)));
+                } else if (action.equalsIgnoreCase("resetbalance")) {
+                    if (!sender.canUseCommand(4, getName())) {
+                        sender.sendMessage(new TextComponentString("Only server operators can use resetbalance."));
+                        return;
+                    }
+                    EconomyManager.setPlayerBalance(world, uuid, 0L);
+                    sender.sendMessage(new TextComponentString("Reset balance for " + targetPlayer.getName()));
                 } else if (args.length >= 4) {
                     long amount = Long.parseLong(args[3]);
                     if (action.equalsIgnoreCase("deposit")) {
@@ -61,6 +73,13 @@ public class CommandEconomy extends CommandBase {
                 if (action.equalsIgnoreCase("get")) {
                     long balance = EconomyManager.getCountryBalance(world, country);
                     sender.sendMessage(new TextComponentString(country + " balance: " + MoneyFormatUtil.format(balance)));
+                } else if (action.equalsIgnoreCase("resetbalance")) {
+                    if (!sender.canUseCommand(4, getName())) {
+                        sender.sendMessage(new TextComponentString("Only server operators can use resetbalance."));
+                        return;
+                    }
+                    EconomyManager.setCountryBalance(world, country, 0L);
+                    sender.sendMessage(new TextComponentString("Reset balance for " + country));
                 } else if (args.length >= 4) {
                     long amount = Long.parseLong(args[3]);
                     if (action.equalsIgnoreCase("deposit")) {


### PR DESCRIPTION
### Motivation
- Allow regular players to run the in-game `/country` and `/economy` commands without operator privileges while keeping the potentially destructive `resetbalance` action restricted to server operators.

### Description
- Set `getRequiredPermissionLevel()` to `0` in `CommandEconomy` and `CountryCommand` so those commands are usable by non-OP players by default.
- Added a `resetbalance` action to `/economy` for both `player` and `country` targets and updated the usage to `"/economy <player|country> <get|deposit|withdraw|resetbalance> <target> [amount]"`.
- Restricted `resetbalance` with an explicit operator check using `sender.canUseCommand(4, getName())` and added informative messages when the caller lacks permission.

### Testing
- Attempted to compile with `./gradlew compileJava`, but the build failed because `JAVA_HOME` is not set and no Java runtime is available in the environment.
- Verified the source diffs and committed the changes on branch `work` with the message "Allow non-OP command usage except balance reset"; no further automated tests were runnable in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993da1169a8833094ea11d3f3d7f7e0)