### PR TITLE
Resolve merge-conflict markers in CommandEconomy

### DIFF
--- a/src/main/java/com/baldeagle/economy/CommandEconomy.java
+++ b/src/main/java/com/baldeagle/economy/CommandEconomy.java
@@ -57,16 +57,6 @@ public class CommandEconomy extends CommandBase {
                 UUID uuid = targetPlayer.getUniqueID();
                 if (action.equalsIgnoreCase("get")) {
                     long balance = EconomyManager.getPlayerBalance(world, uuid);
-<<<<<<< Updated upstream
-                    sender.sendMessage(new TextComponentString(targetPlayer.getName() + " balance: " + MoneyFormatUtil.format(balance)));
-                } else if (action.equalsIgnoreCase("resetbalance")) {
-                    if (!sender.canUseCommand(4, getName())) {
-                        sender.sendMessage(new TextComponentString("Only server operators can use resetbalance."));
-                        return;
-                    }
-                    EconomyManager.setPlayerBalance(world, uuid, 0L);
-                    sender.sendMessage(new TextComponentString("Reset balance for " + targetPlayer.getName()));
-=======
                     sender.sendMessage(
                         new TextComponentString(
                             targetPlayer.getName() +
@@ -74,7 +64,21 @@ public class CommandEconomy extends CommandBase {
                                 MoneyFormatUtil.format(balance)
                         )
                     );
->>>>>>> Stashed changes
+                } else if (action.equalsIgnoreCase("resetbalance")) {
+                    if (!sender.canUseCommand(4, getName())) {
+                        sender.sendMessage(
+                            new TextComponentString(
+                                "Only server operators can use resetbalance."
+                            )
+                        );
+                        return;
+                    }
+                    EconomyManager.setPlayerBalance(world, uuid, 0L);
+                    sender.sendMessage(
+                        new TextComponentString(
+                            "Reset balance for " + targetPlayer.getName()
+                        )
+                    );
                 } else if (args.length >= 4) {
                     long amount = Long.parseLong(args[3]);
                     if (action.equalsIgnoreCase("deposit")) {
@@ -109,17 +113,6 @@ public class CommandEconomy extends CommandBase {
             } else if (type.equalsIgnoreCase("country")) {
                 String country = args[2];
                 if (action.equalsIgnoreCase("get")) {
-<<<<<<< Updated upstream
-                    long balance = EconomyManager.getCountryBalance(world, country);
-                    sender.sendMessage(new TextComponentString(country + " balance: " + MoneyFormatUtil.format(balance)));
-                } else if (action.equalsIgnoreCase("resetbalance")) {
-                    if (!sender.canUseCommand(4, getName())) {
-                        sender.sendMessage(new TextComponentString("Only server operators can use resetbalance."));
-                        return;
-                    }
-                    EconomyManager.setCountryBalance(world, country, 0L);
-                    sender.sendMessage(new TextComponentString("Reset balance for " + country));
-=======
                     long balance = EconomyManager.getCountryBalance(
                         world,
                         country
@@ -131,7 +124,21 @@ public class CommandEconomy extends CommandBase {
                                 MoneyFormatUtil.format(balance)
                         )
                     );
->>>>>>> Stashed changes
+                } else if (action.equalsIgnoreCase("resetbalance")) {
+                    if (!sender.canUseCommand(4, getName())) {
+                        sender.sendMessage(
+                            new TextComponentString(
+                                "Only server operators can use resetbalance."
+                            )
+                        );
+                        return;
+                    }
+                    EconomyManager.setCountryBalance(world, country, 0L);
+                    sender.sendMessage(
+                        new TextComponentString(
+                            "Reset balance for " + country
+                        )
+                    );
                 } else if (args.length >= 4) {
                     long amount = Long.parseLong(args[3]);
                     if (action.equalsIgnoreCase("deposit")) {


### PR DESCRIPTION
### Motivation
- Leftover Git merge-conflict markers in `CommandEconomy.java` caused Java syntax errors and blocked compilation, so the file needed to be cleaned up to restore a valid command implementation.

### Description
- Removed unresolved conflict markers and restored valid Java control flow in `src/main/java/com/baldeagle/economy/CommandEconomy.java`.
- Preserved the formatted multi-line `get` response outputs for both `player` and `country` cases while restoring the `resetbalance` branch for each.
- Kept operator permission checks for `resetbalance` and otherwise retained the original deposit/withdraw logic with no intentional behavioral changes.

### Testing
- Verified conflict markers are gone by running `rg '<<<<<<<|=======|>>>>>>>' src/main/java/com/baldeagle/economy/CommandEconomy.java`, which returned `CLEAN`.
- Attempted `./gradlew build` to validate compilation but it failed in this environment because Java is not installed / `JAVA_HOME` is not set, so full build verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993ecb245248330b563bdf9ee62b11c)